### PR TITLE
feat: use node16 agent

### DIFF
--- a/buildAndReleaseTask/package-lock.json
+++ b/buildAndReleaseTask/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@microsoft/eslint-plugin-sdl": "^0.1.7",
-        "@types/node": "^10.17.60",
+        "@types/node": "16.11.49",
         "@types/q": "^1.5.5",
         "@typescript-eslint/eslint-plugin": "^4.28.5",
         "@typescript-eslint/parser": "^4.28.5",
@@ -233,9 +233,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+      "version": "16.11.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.49.tgz",
+      "integrity": "sha512-Abq9fBviLV93OiXMu+f6r0elxCzRwc0RC5f99cU892uBITL44pTvgvEqlRlPRi8EGcO1z7Cp8A4d0s/p3J/+Nw=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -1341,6 +1341,11 @@
       "dependencies": {
         "@types/node": "^10.0.3"
       }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -2470,9 +2475,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+      "version": "16.11.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.49.tgz",
+      "integrity": "sha512-Abq9fBviLV93OiXMu+f6r0elxCzRwc0RC5f99cU892uBITL44pTvgvEqlRlPRi8EGcO1z7Cp8A4d0s/p3J/+Nw=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -3277,6 +3282,13 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
       }
     },
     "ignore": {

--- a/buildAndReleaseTask/package.json
+++ b/buildAndReleaseTask/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@microsoft/eslint-plugin-sdl": "^0.1.7",
-    "@types/node": "^10.17.60",
+    "@types/node": "16.11.49",
     "@types/q": "^1.5.5",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -30,8 +30,9 @@
         "Build",
         "Release"
     ],
+    "minimumAgentVersion": "2.206.1",
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "index.js"
         }
     }


### PR DESCRIPTION
The `Node16` runner was added in version `2.206.1` of the agent. See the [Node 16 migration guide][1] for more information

[1]: https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode16.md

Signed-off-by: Jamie Magee <jamie.magee@gmail.com>